### PR TITLE
Add support for alternative URL in TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This snippet is highly customizable. Here are the available parameters to change
 | `h_max`    | int    | 6      | the maximum TOC header level to use; any heading greater than this value will be ignored |
 | `ordered`  | bool   | false  | when set to true, an ordered list will be outputted instead of an unordered list |
 | `item_class` | string | ''   | add custom class for each list item; has support for `%level%` placeholder, which is the current heading level |
+| `base_url` | string | ''   | add an base url to the TOC links for when your TOC is on an other page than the actual content |
 
 <sup>*</sup> This is a required parameter
 

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -19,7 +19,7 @@
             * h_max      (int)    :   6    - the maximum TOC header level to use; any header greater than this value will be ignored
             * ordered    (bool)   : false  - when set to true, an ordered list will be outputted instead of an unordered list
             * item_class (string) :   ''   - add custom class for each list item; has support for '%level%' placeholder, which is the current heading level
-            * base_url    (string) :   ''   - Possible to add links to other domains
+            * base_url   (string) :   ''   - add an base url to the TOC links for when your TOC is on an other page than the actual content
 
         Output:
             An ordered or unordered list representing the table of contents of a markdown block. This snippet will only generate the table of contents and will NOT output the markdown given to it

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -19,6 +19,7 @@
             * h_max      (int)    :   6    - the maximum TOC header level to use; any header greater than this value will be ignored
             * ordered    (bool)   : false  - when set to true, an ordered list will be outputted instead of an unordered list
             * item_class (string) :   ''   - add custom class for each list item; has support for '%level%' placeholder, which is the current heading level
+            * base_url    (string) :   ''   - Possible to add links to other domains
 
         Output:
             An ordered or unordered list representing the table of contents of a markdown block. This snippet will only generate the table of contents and will NOT output the markdown given to it
@@ -69,8 +70,7 @@
         {% endunless %}
 
         {% capture my_toc %}{{ my_toc }}
-{{ space }}{{ listModifier }} {{ listItemClass }} [{% if include.sanitize %}{{ header | strip_html }}{% else %}{{ header }}{% endif %}](#{{ html_id }}){% endcapture %}
-
+{{ space }}{{ listModifier }} {{ listItemClass }} [{% if include.sanitize %}{{ header | strip_html }}{% else %}{{ header }}{% endif %}]({% if include.baseurl %}{{ include.baseurl }}{% endif %}#{{ html_id }}){% endcapture %}
     {% endfor %}
 
     {% if include.class %}

--- a/_tests/base_url.md
+++ b/_tests/base_url.md
@@ -1,0 +1,15 @@
+---
+---
+
+{% capture markdown %}
+# Heading 1
+{% endcapture %}
+{% assign text = markdown | markdownify %}
+
+{% include toc.html html=text baseurl="example.org" %}
+
+<!-- /// -->
+
+<ul>
+    <li><a href="example.org#heading-1">Heading 1</a></li>
+</ul>


### PR DESCRIPTION
Sometimes it is useful to be able to point the TOC to a new page. For example in an overview of meeting minutes found here:
https://fordelingsutvalget.org/archive/
https://github.com/cybernetisk/fordelingsutvalget/blob/master/blog/archive.html 

These minutes then point to an alternative page like for example:
https://fordelingsutvalget.org/posts/2018/2018-05-16-Fjerde_M%C3%B8te/#agenda

This does not affect anything other than the href field. And does not break on any valid href.