### PR TITLE
Fixed indenting in ToC when heading levels are skipped

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -50,7 +50,12 @@
             {% assign minHeader = headerLevel %}
         {% endif %}
 
+        {% assign lastIndent = indentAmount %}
         {% assign indentAmount = headerLevel | minus: minHeader | add: 1 %}
+        {% if lastIndent and lastIndent < indentAmount %}
+            {% assign indentAmount = lastIndent | plus: 1 %}
+        {% endif %}
+        
         {% assign _workspace = node | split: '</h' %}
 
         {% assign _idWorkspace = _workspace[0] | split: 'id="' %}

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -39,6 +39,7 @@
             {% continue %}
         {% endif %}
 
+        {% assign lastHeaderLevel = headerLevel %}
         {% assign headerLevel = node | replace: '"', '' | slice: 0, 1 | times: 1 %}
 
         {% if headerLevel < minHeader or headerLevel > maxHeader %}
@@ -52,7 +53,9 @@
 
         {% assign lastIndent = indentAmount %}
         {% assign indentAmount = headerLevel | minus: minHeader | add: 1 %}
-        {% if lastIndent and lastIndent < indentAmount %}
+        {% if lastHeaderLevel and lastHeaderLevel == headerLevel %}
+            {% assign indentAmount = lastIndent %}
+        {% elsif lastIndent and lastIndent < indentAmount %}
             {% assign indentAmount = lastIndent | plus: 1 %}
         {% endif %}
         


### PR DESCRIPTION
Fixed ToC for cases such as:
\# header 1
\#### next header