### PR TITLE
Add support for Jekyll 3.3.x with no consequences

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -67,9 +67,9 @@
             {% assign space = space | prepend: '    ' %}
         {% endfor %}
 
-        {% unless include.item_class == blank %}
+        {% if include.item_class %}
             {% capture listItemClass %}{:.{{ include.item_class | replace: '%level%', headerLevel }}}{% endcapture %}
-        {% endunless %}
+        {% endif %}
 
         {% capture my_toc %}{{ my_toc }}
 {{ space }}{{ listModifier }} {{ listItemClass }} [{% if include.sanitize %}{{ header | strip_html }}{% else %}{{ header }}{% endif %}]({% if include.baseurl %}{{ include.baseurl }}{% endif %}#{{ html_id }}){% if include.anchor_class %}{:.{{ include.anchor_class }}}{% endif %}{% endcapture %}


### PR DESCRIPTION
For a reason I'm too lazy to investigate, Jekyll 3.3.x doesn't correctly handle either an `{% unless %}` or a `== blank`. Changing this condition to an `{% if %}` has the same benefit and it works the same.

If I can add support for more versions of Jekyll without any consequences, why not do it.