### PR TITLE
Add .no_toc support

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,6 +1,6 @@
 {% capture tocWorkspace %}
     {% comment %}
-        Version 1.0.6
+        Version 1.0.7
           https://github.com/allejo/jekyll-toc
 
         "...like all things liquid - where there's a will, and ~36 hours to spare, there's usually a/some way" ~jaybe
@@ -58,6 +58,14 @@
         {% assign _idWorkspace = _workspace[0] | split: 'id="' %}
         {% assign _idWorkspace = _idWorkspace[1] | split: '"' %}
         {% assign html_id = _idWorkspace[0] %}
+
+        {% assign _classWorkspace = _workspace[0] | split: 'class="' %}
+        {% assign _classWorkspace = _classWorkspace[1] | split: '"' %}
+        {% assign html_class = _classWorkspace[0] %}
+
+        {% if html_class contains "no_toc" %}
+            {% continue %}
+        {% endif %}
 
         {% capture _hAttrToStrip %}{{ _workspace[0] | split: '>' | first }}>{% endcapture %}
         {% assign header = _workspace[0] | replace: _hAttrToStrip, '' %}

--- a/_tests/noTocClass.md
+++ b/_tests/noTocClass.md
@@ -1,0 +1,31 @@
+---
+# see https://github.com/allejo/jekyll-toc/issues/15
+---
+
+{% capture markdown %}
+# Contents header
+{:.no_toc}
+
+* A markdown unordered list which will be replaced with the ToC, excluding the "Contents header" from above
+{:toc}
+
+# H1 header
+
+## H2 header
+{% endcapture %}
+{% assign text = markdown | markdownify %}
+
+{% include toc.html html=text %}
+
+<!-- /// -->
+
+<ul>
+    <li>
+        <a href="#h1-header">H1 header</a>
+        <ul>
+            <li>
+                <a href="#h2-header">H2 header</a>
+            </li>
+        </ul>
+    </li>
+</ul>

--- a/_tests/noTocClassMultipleClasses.md
+++ b/_tests/noTocClassMultipleClasses.md
@@ -1,0 +1,34 @@
+---
+# If a heading has `no_toc` with other classes, it should still ignore it from
+# the TOC
+# see https://github.com/allejo/jekyll-toc/issues/15
+---
+
+{% capture markdown %}
+# Contents header
+{:.no_toc.another-class}
+
+* A markdown unordered list which will be replaced with the ToC, excluding the "Contents header" from above
+{:toc}
+
+# H1 header
+{:.custom-class}
+
+## H2 header
+{% endcapture %}
+{% assign text = markdown | markdownify %}
+
+{% include toc.html html=text %}
+
+<!-- /// -->
+
+<ul>
+    <li>
+        <a href="#h1-header">H1 header</a>
+        <ul>
+            <li>
+                <a href="#h2-header">H2 header</a>
+            </li>
+        </ul>
+    </li>
+</ul>


### PR DESCRIPTION
If a heading has the `no_toc` class, then this snippet should exclude the heading from the rendered TOC.

Closes #15