### PR TITLE
Escape pipes in TOC generation

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -79,8 +79,9 @@
             {% capture listItemClass %}{:.{{ include.item_class | replace: '%level%', headerLevel }}}{% endcapture %}
         {% endunless %}
 
+        {% capture heading_body %}{% if include.sanitize %}{{ header | strip_html }}{% else %}{{ header }}{% endif %}{% endcapture %}
         {% capture my_toc %}{{ my_toc }}
-{{ space }}{{ listModifier }} {{ listItemClass }} [{% if include.sanitize %}{{ header | strip_html }}{% else %}{{ header }}{% endif %}]({% if include.baseurl %}{{ include.baseurl }}{% endif %}#{{ html_id }}){% if include.anchor_class %}{:.{{ include.anchor_class }}}{% endif %}{% endcapture %}
+{{ space }}{{ listModifier }} {{ listItemClass }} [{{ heading_body | replace: "|", "\|" }}]({% if include.baseurl %}{{ include.baseurl }}{% endif %}#{{ html_id }}){% if include.anchor_class %}{:.{{ include.anchor_class }}}{% endif %}{% endcapture %}
     {% endfor %}
 
     {% if include.class %}

--- a/_tests/headingWithPipes.md
+++ b/_tests/headingWithPipes.md
@@ -1,0 +1,20 @@
+---
+# see https://github.com/allejo/jekyll-toc/issues/23
+---
+
+{% capture markdown %}
+# ZDE015 - Connects to [Trigger|Search|Action] NAME, Which Doesn't Exist
+{% endcapture %}
+{% assign text = markdown | markdownify %}
+
+{% include toc.html html=text %}
+
+<!-- /// -->
+
+<ul>
+    <li>
+        <a href="#zde015---connects-to-triggersearchaction-name-which-doesnt-exist">
+            ZDE015 - Connects to [Trigger|Search|Action] NAME, Which Doesn&#8217;t Exist
+        </a>
+    </li>
+</ul>


### PR DESCRIPTION
Looks like kramdown treats `|`s in a list item as a table and renders it as such.

Guess we should escape it from:

```
- ZDE015 - Connects to [Trigger|Search|Action] NAME, Which Doesn't Exist
```

to:

```
- ZDE015 - Connects to [Trigger\|Search\|Action] NAME, Which Doesn't Exist
```

Fixes #23

/cc @xavdid