### PR TITLE
Fix logic mistake in toc.html

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -52,7 +52,7 @@
             {% assign minHeader = headerLevel %}
         {% endif %}
 
-        {% assign indentAmount = headerLevel | minus: minHeader | add: 1 %}
+        {% assign indentAmount = headerLevel | minus: minHeader %}
         {% assign _workspace = node | split: '</h' %}
 
         {% assign _idWorkspace = _workspace[0] | split: 'id="' %}


### PR DESCRIPTION
Liquid do not have filter named <tt>{{ add }}</tt> or I don't know. What do you mean by that ?. I guess that's <tt>{{ plus }}</tt>. In that case, we prepend a extra space on 1st level of headers so it will stop kramdown from working right. So I was thinking it's a logic error.
# **Preview**
### *Remove* &middot; <tt>add: 1</tt>
![normal_toc](https://user-images.githubusercontent.com/45516672/63182998-2757f980-c07e-11e9-819a-9f0ee94ae686.jpg)
![normal_toc_2](https://user-images.githubusercontent.com/45516672/63183025-350d7f00-c07e-11e9-83dd-9638d747ee87.jpg)
### * Change &middot <tt>add: 1</tt> to <tt>plus: 1</tt> ** 
![abnormal_toc](https://user-images.githubusercontent.com/45516672/63183037-3b9bf680-c07e-11e9-8c13-d28ea30c8dad.jpg)
![abnormal_toc_2](https://user-images.githubusercontent.com/45516672/63183051-4060aa80-c07e-11e9-9a25-dfd524c82d5a.jpg)



