### PR TITLE
Fix logic errors on rendering list item classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 _site
 .sass-cache
+.jekyll-cache
 .jekyll-metadata
 Gemfile.lock
 vendor

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,6 +1,6 @@
 {% capture tocWorkspace %}
     {% comment %}
-        Version 1.0.8
+        Version 1.0.9
           https://github.com/allejo/jekyll-toc
 
         "...like all things liquid - where there's a will, and ~36 hours to spare, there's usually a/some way" ~jaybe
@@ -75,16 +75,16 @@
             {% assign space = space | prepend: '    ' %}
         {% endfor %}
 
-        {% unless include.item_class == blank %}
+        {% if include.item_class and include.item_class != blank %}
             {% capture listItemClass %}{:.{{ include.item_class | replace: '%level%', headerLevel }}}{% endcapture %}
-        {% endunless %}
+        {% endif %}
 
         {% capture heading_body %}{% if include.sanitize %}{{ header | strip_html }}{% else %}{{ header }}{% endif %}{% endcapture %}
         {% capture my_toc %}{{ my_toc }}
 {{ space }}{{ listModifier }} {{ listItemClass }} [{{ heading_body | replace: "|", "\|" }}]({% if include.baseurl %}{{ include.baseurl }}{% endif %}#{{ html_id }}){% if include.anchor_class %}{:.{{ include.anchor_class }}}{% endif %}{% endcapture %}
     {% endfor %}
 
-    {% if include.class %}
+    {% if include.class and include.item_class != blank %}
         {% capture my_toc %}{:.{{ include.class }}}
 {{ my_toc | lstrip }}{% endcapture %}
     {% endif %}


### PR DESCRIPTION
kramdown is nice enough to trim and ignore `{:.}` but it was still being generated on list items, which is incorrect behavior (see #26 for another logic mistake). This PR inadvertently, partially fixes redcarpet support.

redcarpet is still not officially supported by this project since [redcarpet support was dropped in Jekyll 4](https://github.com/jekyll/jekyll/pull/6987) and [GitHub Pages no longer supports it](https://github.blog/2016-04-01-a-look-behind-our-decision-to-standardize-on-a-single-markdown-engine-for-github-pages/).

This change does **NOT** change any outputted HTML.