### PR TITLE
Skip heading as "first heading" if has .no_toc

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,6 +1,6 @@
 {% capture tocWorkspace %}
     {% comment %}
-        Version 1.0.11
+        Version 1.0.12
           https://github.com/allejo/jekyll-toc
 
         "...like all things liquid - where there's a will, and ~36 hours to spare, there's usually a/some way" ~jaybe

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -55,12 +55,6 @@
             {% continue %}
         {% endif %}
 
-        {% if firstHeader %}
-            {% assign firstHeader = false %}
-            {% assign minHeader = headerLevel %}
-        {% endif %}
-
-        {% assign indentAmount = headerLevel | minus: minHeader %}
         {% assign _workspace = node | split: '</h' %}
 
         {% assign _idWorkspace = _workspace[0] | split: 'id="' %}
@@ -75,9 +69,15 @@
             {% continue %}
         {% endif %}
 
+        {% if firstHeader %}
+            {% assign firstHeader = false %}
+            {% assign minHeader = headerLevel %}
+        {% endif %}
+
         {% capture _hAttrToStrip %}{{ _workspace[0] | split: '>' | first }}>{% endcapture %}
         {% assign header = _workspace[0] | replace: _hAttrToStrip, '' %}
 
+        {% assign indentAmount = headerLevel | minus: minHeader %}
         {% assign space = '' %}
         {% for i in (1..indentAmount) %}
             {% assign space = space | prepend: '    ' %}

--- a/_tests/noTocForFirstHeading copy.md
+++ b/_tests/noTocForFirstHeading copy.md
@@ -1,0 +1,37 @@
+---
+# See https://github.com/allejo/jekyll-toc/issues/35
+---
+
+{% capture markdown %}
+## skip me
+{: .no_toc}
+
+## skip me also
+{: .no_toc}
+
+## skip me, too...
+{: .no_toc}
+
+## skip me last
+{: .no_toc}
+
+### also skip me as a subheading!
+{: .no_toc}
+
+### Subheading A
+
+### Subheading B
+
+### Subheading C
+{% endcapture %}
+{% assign text = markdown | markdownify %}
+
+{% include toc.html html=text %}
+
+<!-- /// -->
+
+<ul>
+    <li><a href="#subheading-a">Subheading A</a></li>
+    <li><a href="#subheading-b">Subheading B</a></li>
+    <li><a href="#subheading-c">Subheading C</a></li>
+</ul>

--- a/_tests/noTocForFirstHeading.md
+++ b/_tests/noTocForFirstHeading.md
@@ -1,0 +1,25 @@
+---
+# See https://github.com/allejo/jekyll-toc/issues/35
+---
+
+{% capture markdown %}
+## some prominent header i want to hide
+{: .no_toc}
+
+### Subheading A
+
+### Subheading B
+
+### Subheading C
+{% endcapture %}
+{% assign text = markdown | markdownify %}
+
+{% include toc.html html=text %}
+
+<!-- /// -->
+
+<ul>
+    <li><a href="#subheading-a">Subheading A</a></li>
+    <li><a href="#subheading-b">Subheading B</a></li>
+    <li><a href="#subheading-c">Subheading C</a></li>
+</ul>


### PR DESCRIPTION
Don't assign our "first header" variable until after we've hit our first non-`.no_toc` heading.

Fixes #35

/cc @Philzen