### PR TITLE
Add license comment.

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -110,3 +110,23 @@
 {{ my_toc | lstrip }}{% endcapture %}
     {% endif %}
 {% endcapture %}{% assign tocWorkspace = '' %}{{ my_toc | markdownify | strip }}
+{% comment %}
+Copyright © 2017 Vladimir Jimenez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+{% endcomment %}


### PR DESCRIPTION
“Under the MIT license for the toc.html file,” a lawyer friend assures me, “we can use it if we add the copyright notice, etc., into a comment in the file. We do not need to repeat that license information in our LICENSE file.”

So making this change would help many of your users to stay within the letter of the law.  I notice several of the projects using the template do not seem to have matching licenses or have made any special provisions.

It's no problem at all for me if you choose not to accept this PR; just trying to help out.