### PR TITLE
Fix skipNoIDs logic when more IDs in other HTML elements

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -67,12 +67,6 @@
             {% continue %}
         {% endif %}
 
-        {% if skipNoIDs == true %}
-            {% unless node contains "id=" %}
-                {% continue %}
-            {% endunless %}
-        {% endif %}
-
         {% assign headerLevel = node | replace: '"', '' | slice: 0, 1 | times: 1 %}
 
         {% if headerLevel < minHeader or headerLevel > maxHeader %}
@@ -116,6 +110,8 @@
 
         {% if html_id %}
             {% capture list_item %}[{{ anchor_body }}]({% if include.baseurl %}{{ include.baseurl }}{% endif %}#{{ html_id }}){% endcapture %}
+        {% elsif skipNoIDs == true %}
+            {% continue %}
         {% else %}
             {% capture list_item %}{{ anchor_body }}{% endcapture %}
         {% endif %}

--- a/_tests/skipHeadingsWithNoIDs.md
+++ b/_tests/skipHeadingsWithNoIDs.md
@@ -8,6 +8,7 @@
 <div>
   <h1 class="page-title">My Awesome Example Page</h1>
   <h2 class="page-subtitle">With an awesome subtitle</h2>
+    <a href='/' id="dummy-link">Dummy Link</a>
 </div>
 
 ### Known Problems

--- a/_tests/skipHeadingsWithNoIDs.md
+++ b/_tests/skipHeadingsWithNoIDs.md
@@ -8,7 +8,7 @@
 <div>
   <h1 class="page-title">My Awesome Example Page</h1>
   <h2 class="page-subtitle">With an awesome subtitle</h2>
-    <a href='/' id="dummy-link">Dummy Link</a>
+  <a href='/' id="dummy-link">Dummy Link</a>
 </div>
 
 ### Known Problems


### PR DESCRIPTION
_Related to PR #32 & #33._

Currently, headers without ids would still be added to the TOC with `skipNoIDs=true` if there are ids in other HTML elements between two headers.

**Markdown**
```markdown
{% capture markdown %}
## Sample Usage

<div>
  <h1 class="page-title">My Awesome Example Page</h1>
  <h2 class="page-subtitle">With an awesome subtitle</h2>
    <a href='/' id="dummy-link">Dummy Link</a>
</div>

### Known Problems

Lots!

### Resources

#### Paid

#### Free
{% endcapture %}
{% assign text = markdown | markdownify %}
```

**TOC Usage**

```twig
{% include toc.html html=text skipNoIDs=true %}
```

**Expected TOC**

```html
<ul>
    <li>
        <a href="#sample-usage">Sample Usage</a>
        <ul>
            <li>
                <a href="#known-problems">Known Problems</a>
            </li>
            <li>
                <a href="#resources">Resources</a>
                <ul>
                    <li>
                        <a href="#paid">Paid</a>
                    </li>
                    <li>
                        <a href="#free">Free</a>
                    </li>
                </ul>
            </li>
        </ul>
    </li>
</ul>
```

**Actual TOC**
```html
<ul>
  <li><a href="#sample-usage">Sample Usage</a></li>
  <li>With an awesome subtitle
    <ul>
      <li><a href="#known-problems">Known Problems</a></li>
      <li><a href="#resources">Resources</a>
        <ul>
          <li><a href="#paid">Paid</a></li>
          <li><a href="#free">Free</a></li>
        </ul>
      </li>
    </ul>
  </li>
</ul>
```