### PR TITLE
Trim trailing line to ensure empty toc is empty

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -179,4 +179,4 @@
             {% capture jekyll_toc %}<{{ listModifier }}{{ rootAttributes }}>{{ nodes | shift | join: '>' }}>{% endcapture %}
         {% endif %}
     {% endif %}
-{% endcapture %}{% assign tocWorkspace = '' %}{{ deprecation_warnings }}{{ jekyll_toc }}
+{% endcapture %}{% assign tocWorkspace = '' %}{{ deprecation_warnings }}{{ jekyll_toc -}}

--- a/_tests/allowCheckEmptyToc.md
+++ b/_tests/allowCheckEmptyToc.md
@@ -1,0 +1,15 @@
+---
+# See https://github.com/allejo/jekyll-toc/pull/60
+---
+
+{% capture jekyll_toc %}{% include toc.html html="" %}{% endcapture %}
+
+{% if jekyll_toc == "" -%}
+  <p>Success</p>
+{%- else -%}
+  <p>Failure</p>
+{%- endif %}
+
+<!-- /// -->
+
+<p>Success</p>


### PR DESCRIPTION
Use case:

```
{%- if include.toc -%}
	{%- capture jekyll_toc -%}{%- include toc.html html=content -%}{%- endcapture -%}
	{%- if jekyll_toc != '' -%}
		<div class="toc-wrapper">
		<h4>Table of contents</h4>{{ jekyll_toc }}</div>
	{%- endif -%}
{%- endif -%}
```

It is also possible to store the `toc.html` layout file in the Git repository without trailing newline. However, when copying it into other projects this is often not preserved since trailing newline at EOF is a commonly enforced convention by various tooling, including Git itself, and in text editors when merely opening the file to e.g. copy/paste the latest version.