### PR TITLE
Fix Unit Tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ The `<!-- /// -->` is the directive used to tell our Python script where the act
 
 ### Running Tests
 
-Build the Jekyll site which processes all of our tests along with our current TOC snippet and then run the Python script (requires 2.7).
+Build the Jekyll site which processes all of our tests along with our current TOC snippet and then run the Python 3 script.
 
 ```bash
 bundle exec jekyll build

--- a/_tests/headingWithPipes.md
+++ b/_tests/headingWithPipes.md
@@ -3,7 +3,7 @@
 ---
 
 {% capture markdown %}
-# ZDE015 - Connects to [Trigger|Search|Action] NAME, Which Doesn't Exist
+# ZDE015 - Connects to [Trigger|Search|Action] NAME, Which Does Not Exist
 {% endcapture %}
 {% assign text = markdown | markdownify %}
 
@@ -13,8 +13,8 @@
 
 <ul>
     <li>
-        <a href="#zde015---connects-to-triggersearchaction-name-which-doesnt-exist">
-            ZDE015 - Connects to [Trigger|Search|Action] NAME, Which Doesn&#8217;t Exist
+        <a href="#zde015---connects-to-triggersearchaction-name-which-does-not-exist">
+            ZDE015 - Connects to [Trigger|Search|Action] NAME, Which Does Not Exist
         </a>
     </li>
 </ul>


### PR DESCRIPTION
## Quote in `headingWithPipes.md`

Previous unit test `headingWithPipes` fails because of the quote.

The HTML generated by Jekyll in `_site/`:

```
<li>Doesn’t</li>

<!-- /// -->

<li>Doesn&#8217;t</li>
```

(It's more complicated in original version. I manually edit the HTML file to this.)

What `tests.py` thinks:

```
ACTUAL: <li>Doesn&#37413;&#27291; Exist</li>
EXPECT: <li>Doesn&#8217;t Exist</li>
```

If I add `encoding='utf-8'` when opening files in `tests.py`, it becomes `OK`. (python `open()` with GBK by default on Windows 10 Chinese ver. — [It depends on locale.](https://docs.python.org/3/library/functions.html?highlight=locale#open)) Therefore, this might be a platform-dependent issue, and do not imply `toc.html` or Jekyll works wrongly.

So I remove the quote.


## Python 2.7 in Contributing Guide

Change the python version from 2.7 to 3 in contributing guide. I think it was a mistake.

<details>
<summary>Details on the Python Version</summary>

The [contributing guide](https://github.com/allejo/jekyll-toc/blob/8d5aafdfe92559bbc5ea621e98ab01dba48a427c/CONTRIBUTING.md#running-tests) says

>  run the Python script (requires 2.7)

In `tests.py`, there's even f-string (a python 3.6 feature)!

https://github.com/allejo/jekyll-toc/blob/8d5aafdfe92559bbc5ea621e98ab01dba48a427c/tests.py#L18

I run `tests.py` in python 3.7 - 3.10, and all works. (python 2.7 and 3.6 are both *end-of-life*)

</details>
